### PR TITLE
Android security 11.0.0 release 61

### DIFF
--- a/drm/mediadrm/plugins/clearkey/hidl/DrmPlugin.cpp
+++ b/drm/mediadrm/plugins/clearkey/hidl/DrmPlugin.cpp
@@ -623,6 +623,7 @@ Return<void> DrmPlugin::getSecurityLevel(const hidl_vec<uint8_t>& sessionId,
         return Void();
     }
 
+    Mutex::Autolock lock(mSecurityLevelLock);
     std::map<std::vector<uint8_t>, SecurityLevel>::iterator itr =
             mSecurityLevel.find(sid);
     if (itr == mSecurityLevel.end()) {
@@ -653,6 +654,7 @@ Return<Status> DrmPlugin::setSecurityLevel(const hidl_vec<uint8_t>& sessionId,
         return Status::ERROR_DRM_SESSION_NOT_OPENED;
     }
 
+    Mutex::Autolock lock(mSecurityLevelLock);
     std::map<std::vector<uint8_t>, SecurityLevel>::iterator itr =
             mSecurityLevel.find(sid);
     if (itr != mSecurityLevel.end()) {

--- a/drm/mediadrm/plugins/clearkey/hidl/include/DrmPlugin.h
+++ b/drm/mediadrm/plugins/clearkey/hidl/include/DrmPlugin.h
@@ -398,7 +398,8 @@ private:
     std::map<std::string, std::string> mStringProperties;
     std::map<std::string, std::vector<uint8_t> > mByteArrayProperties;
     std::map<std::string, std::vector<uint8_t> > mReleaseKeysMap;
-    std::map<std::vector<uint8_t>, SecurityLevel> mSecurityLevel;
+    std::map<std::vector<uint8_t>, SecurityLevel> mSecurityLevel
+        GUARDED_BY(mSecurityLevelLock);
     sp<IDrmPluginListener> mListener;
     sp<IDrmPluginListener_V1_2> mListenerV1_2;
     SessionLibrary *mSessionLibrary;
@@ -419,6 +420,7 @@ private:
     DeviceFiles mFileHandle GUARDED_BY(mFileHandleLock);
     Mutex mFileHandleLock;
     Mutex mSecureStopLock;
+    Mutex mSecurityLevelLock;
 
     CLEARKEY_DISALLOW_COPY_AND_ASSIGN_AND_NEW(DrmPlugin);
 };


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r61' of https://android.googlesource.com/platform/frameworks/av into arrow-11.0

Android security 11.0.0 release 61
Tag: https://android.googlesource.com/platform/frameworks/av/+/refs/tags/android-security-11.0.0_r61

Merge cherrypicks of [19536772] into security-aosp-rvc-release.

Change-Id: [I1ed2fb841700fe62db2730ab335c6f79acd0fbaa](https://android-review.googlesource.com/#/q/I1ed2fb841700fe62db2730ab335c6f79acd0fbaa)